### PR TITLE
Add getViewCreators

### DIFF
--- a/Sources/ViewExtractor/ViewExtractor.swift
+++ b/Sources/ViewExtractor/ViewExtractor.swift
@@ -58,11 +58,22 @@ public enum ViewExtractor {
         }
     }
     
+    /// Gets view creators from `Any`. Also splits up `DynamicViewContent` into separate views.
+    /// - Parameter view: View of `Any` type.
+    /// - Returns: View creators contained by this `view`.
     public static func viewCreators(from view: Any) -> [() -> AnyView] {
+        if view is EmptyView {
+            return []
+        }
         if let forEach = view as? DynamicViewContentProvider {
             return forEach.extractCreators()
         }
-        return []
+        return withUnsafeBytes(of: view) { ptr -> [() -> AnyView] in
+            if let genericView = ptr.bindMemory(to: GenericView.self).first {
+                return [genericView.anyViewCreator]
+            }
+            return []
+        }
     }
 }
 


### PR DESCRIPTION
Hey, not sure if you're even interested in adding getViewCreators functionality, but I'm making this PR in hopes that you might be able to provide some guidance, if that's alright! I think there's still some handling missing in my code.

1) I see that extractContent() unpacks the view `let newContent = content(element)` and checks if it's EmptyView or not. I guess this isn't possible with getViewCreators since the idea is to not unpack the views yet. I wonder if this is a big problem? I'm not totally sure in what cases the view would be EmptyView.

2) In `views(from view: Any)` it looks like if the view is not EmptyView or castable to DynamicViewContentProvider, you're doing some handling that I don't quite understand.

        return withUnsafeBytes(of: view) { ptr -> [AnyView] in
            let binded = ptr.bindMemory(to: GenericView.self)
            return binded.first?.anyView.map { [$0] } ?? []
        }

I'm not sure what case this is covering, and how I might adapt it to getViewCreators. It seems to be there to handle cases that are just simple views (like not ForEach)?

Edit: I've added some handling for (2) that seems to work. The issue is that it could possibly result in a view creator that returns AnyView(EmptyView()). This was already an issue though I guess as mentioned in (1). I suppose a user would have to check for the possibility of an EmptyView being returned. I'll have to think about it, but that might(?) be okay for my use case, but maybe not clear enough for other people to use, so maybe this can't be merged!